### PR TITLE
docs: add CLAUDE.md and update resume career status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,100 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a personal resume/portfolio website built with Next.js 15, featuring a static export setup for GitHub Pages deployment. The site displays a professional resume parsed from Markdown with frontmatter, styled with Tailwind CSS.
+
+## Key Commands
+
+### Development
+- `yarn dev` or `npm run dev` - Start development server on localhost:3000
+- `yarn build` or `npm run build` - Build production version
+- `yarn start` or `npm start` - Start production server
+- `yarn export` or `npm run export` - Export static files
+
+### Quality Assurance
+- `yarn lint` or `npm run lint` - Run ESLint and text linting (checks both code and content)
+- `yarn lint:text` - Run textlint on markdown files (Japanese language rules)
+
+### Deployment
+- `yarn deploy` or `npm run deploy` - Build and prepare for GitHub Pages (creates `.nojekyll`)
+
+### PDF Generation
+- `yarn build:pdf` - Generate PDF from resume markdown using md-to-pdf
+
+## Architecture
+
+### File Structure
+- `/src/app/` - Next.js App Router pages and layouts
+- `/src/components/` - React components (Sidebar, BrandIcons, type definitions)
+- `/contents/` - Markdown content files (currently `resume.md`)
+- `/public/` - Static assets
+- `/pdf-configs/` - Configuration for PDF generation
+
+### Core Components
+- **Layout** (`src/app/layout.tsx`) - Root layout with sidebar and main content areas
+- **Home Page** (`src/app/page.tsx`) - Dynamically renders resume content from markdown
+- **Sidebar** (`src/components/Sidebar.tsx`) - Profile info and contact links
+- **BrandIcons** (`src/components/BrandIcons.tsx`) - Custom SVG icons for social platforms
+
+### Content Management
+Resume content is stored in `/contents/resume.md` with frontmatter for metadata. The file uses gray-matter for parsing and remark for markdown-to-HTML conversion.
+
+### Styling
+- Tailwind CSS with typography plugin for prose styling
+- Responsive design with mobile-first approach
+- Custom color scheme using slate and blue palettes
+
+### Static Export Configuration
+- Next.js configured for static export (`output: 'export'`)
+- Images are unoptimized for static hosting
+- Trailing slashes enabled for GitHub Pages compatibility
+
+### Text Quality
+Extensive textlint configuration for Japanese content quality, including rules for:
+- Technical writing standards
+- Typography and spacing
+- Language-specific grammar rules
+
+## Development Notes
+
+- Uses TypeScript throughout
+- Configured for static site deployment on GitHub Pages
+- Resume content supports Japanese language with specialized linting rules
+- Images are loaded from external sources (GitHub profile pictures)
+- PDF export capability for resume distribution
+
+## Pull Request Templates
+### Japanese/English PR Template
+```markdown
+
+## Background / 背景
+
+[English description]
+[日本語の説明]
+
+## Changes / 変更内容
+
+[English changes]
+[日本語の変更内容]
+
+## Impact scope / 影響範囲
+
+[English impact]
+[日本語の影響範囲]
+
+## Testing / 動作確認
+
+- [x] Test item 1 / テスト項目1
+- [x] Test item 2 / テスト項目2
+```
+
+### Conventional Commits
+
+```bash
+<type>[optional scope]: <description>
+```
+type: feat, fix, refactor, ci, perf, docs, chore
+ 

--- a/contents/resume.md
+++ b/contents/resume.md
@@ -5,9 +5,8 @@ description: "Software Engineer Resume"
 
 
 ## 経歴
-- 2023.06 - 現在: 株式会社ダイニー
-- 2021.12 - 2023.01: OLTA株式会社 ※業務委託
-- 2022.11 - 2023.05: 株式会社ダイニー ※業務委託
+- 2025.08 - 現在: OLTA 株式会社
+- 2023.06 - 2025.08: 株式会社 ダイニー
 - 2021.01 - 2023.05: 株式会社OpenFashion (旧株式会社OMNIS) 
 - 2018.09 - 2020.12: auコマース＆ライフ株式会社
 - 2015.04 - 2018.09: 株式会社アウトソーシングテクノロジー
@@ -31,12 +30,12 @@ description: "Software Engineer Resume"
 ## 技術スタック
 
 ### Application Language
-- Golang, Python, Node.js, Java, PHP, C#
-- TypeScript, JavaScript
+- TypeScript, Golang, Python, 
+- (Java, PHP, C#)
 
 ### Framework
-- Nest.js, go-chi, sql boiler, Django, Spring, Laravel
-- Nest.js, React.js, Vue.js
+- Next.js, Nest.js, go-chi, sql boiler, Django, 
+- Spring, Laravel
 
 
 ### Middleware
@@ -56,7 +55,9 @@ description: "Software Engineer Resume"
 
 ## 職務経歴詳細 (プロパー)
 
-### [株式会社ダイニー (2023/06~現在)](https://www.dinii.jp/)
+### [OLTA 株式会社 (2025/08~)](https://corp.olta.co.jp/)
+
+### [株式会社 ダイニー (2023/06~2025/08)](https://www.dinii.jp/)
 
 **Platform Engineer  (2023/06~現在)**
 
@@ -87,7 +88,7 @@ description: "Software Engineer Resume"
 
 
 
-### [株式会社OpenFashion (旧株式会社OMNIS) (2021/01〜2023/5)](https://www.omnisinc.co/)
+### [株式会社 OpenFashion (旧株式会社OMNIS) (2021/01〜2023/5)](https://www.omnisinc.co/)
 
 **生産管理システムにおけるリードエンジニア**
 
@@ -111,7 +112,7 @@ description: "Software Engineer Resume"
     - React, Vercelを用いたフロントエンド開発
 
 
-### [auコマース&ライフ株式会社（2018/09〜2020/12）](https://www.au-cl.co.jp/)
+### [auコマース&ライフ 株式会社（2018/09〜2020/12）](https://www.au-cl.co.jp/)
 **モール型 EC 事業における分析基盤（DMP）構築**
 
 - モール型 EC 事業における各種企画や、KDDI の広告効果測定を目的とした DMP（Data Management Platform）の構築・運用を担当。
@@ -132,7 +133,7 @@ description: "Software Engineer Resume"
     - AWS、GCP、Terraform を用いた DMP 基盤構築
     - Tableau によるダッシュボード作成およびデータ可視化
 
-### [株式会社アウトソーシングテクノロジー（2015/04〜2018/09）](https://www.ostechnology.co.jp/)
+### [株式会社 アウトソーシングテクノロジー（2015/04〜2018/09）](https://www.ostechnology.co.jp/)
 新卒で入社。開発を中心に設計からテストまで携わり、主にバックエンドを中心に作業を行ってきた。
 受託会社のため案件毎に利用する技術が変わるため、参画した後に円滑に業務が行えるように新しい技術のキャッチアップの仕方を学んだ。
 
@@ -146,7 +147,7 @@ description: "Software Engineer Resume"
 
 
 ## 職務経歴詳細 (業務委託)
-### [株式会社ダイニー (2022/11~2023/05)](https://www.dinii.jp/)
+### [株式会社 ダイニー (2022/11~2023/05)](https://www.dinii.jp/)
 当初はパフォーマンスと安定性を求めたインフラを構築するための採用となっていたが、特定の領域に固定せずフルスタックにタスクを着手した。
 自分のキャリアとしては初めて React Native を用いたモバイルのフロント開発に携わり、フィルタ機能の実装などを行った。
 
@@ -160,7 +161,7 @@ description: "Software Engineer Resume"
     - React Nativeによるモバイル開発
 
 
-### [OLTA株式会社 (2021/12〜現在)](http://corp.olta.co.jp/)
+### [OLTA 株式会社 (2021/12〜2023/11)](http://corp.olta.co.jp/)
 審査情報をDataLakeへ取り込むためのプログラムの作成を行った。
 前任者が作成した類似物があったが、イメージ内部にクラウドの認証情報を持つ作りになっており、コンテナ利用も簡素なものとなっていた。
 そのため今回はdocker-composeを用いたり、必要なバイナリのみをイメージに含めることで、コンテナ周りのナレッジを組織に共有した。


### PR DESCRIPTION
## Background / 背景

Added comprehensive development documentation for future Claude Code instances and updated resume to reflect current employment status.

開発者向けドキュメント「CLAUDE.md」の追加と、現在の転職状況を反映した履歴書の更新を行いました。

## Changes / 変更内容

- **Added CLAUDE.md**: Comprehensive documentation including development commands, architecture overview, and project structure guidance for Claude Code instances
- **Updated resume**: Corrected employment timeline to show OLTA as current employer (2025.08-present) and Dinii tenure (2023.06-2025.08)
- **Improved formatting**: Minor spacing and consistency improvements in resume content

- **CLAUDE.md の追加**: Claude Code インスタンス向けの開発コマンド、アーキテクチャ概要、プロジェクト構造ガイダンスを含む包括的なドキュメント
- **履歴書の更新**: OLTA を現在の雇用者（2025.08〜現在）、Dinii の在籍期間（2023.06〜2025.08）として正しい雇用タイムラインに修正
- **フォーマット改善**: 履歴書コンテンツの軽微なスペーシングと一貫性の改善

## Impact scope / 影響範囲

- Documentation improvement for development workflow
- Resume accuracy for current employment status
- No breaking changes to existing functionality

- 開発ワークフローのドキュメント改善
- 現在の雇用状況に対する履歴書の正確性向上
- 既存機能への破壊的変更なし

## Testing / 動作確認

- [x] Verified CLAUDE.md contains all essential development information / CLAUDE.mdに必要な開発情報が含まれていることを確認
- [x] Confirmed resume displays correctly with updated employment information / 更新された雇用情報で履歴書が正しく表示されることを確認
- [x] All linting rules pass for both code and content / コードとコンテンツの両方でリンティングルールが通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)