### PR TITLE
docs: remove yarn export command references from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,19 +48,16 @@ npm run dev
 
 Open [http://localhost:3000](http://localhost:3000) to view the site.
 
-### Build & Export
+### Build
 
 ```bash
-# Build for production
+# Build for production (includes static export)
 yarn build
 # or
 npm run build
-
-# Export static files
-yarn export
-# or
-npm run export
 ```
+
+The build process automatically generates static files in the `out` directory for deployment.
 
 ## 📝 Content Management
 
@@ -76,9 +73,10 @@ Resume content is stored in `/contents/resume.md` with frontmatter for metadata.
 ## 🔧 Available Scripts
 
 - `yarn dev` - Start development server
-- `yarn build` - Build production version
-- `yarn export` - Export static files
+- `yarn build` - Build production version with static export
+- `yarn start` - Start production server
 - `yarn lint` - Run ESLint and text linting
+- `yarn lint:text` - Run textlint on markdown content
 
 ## 📁 Project Structure
 


### PR DESCRIPTION
## Background / 背景

The `yarn export` command no longer exists in package.json, but documentation still references it, causing confusion for developers.
`yarn export`コマンドはpackage.jsonに存在しませんが、ドキュメントでまだ参照されており、開発者の混乱を招いています。

## Changes / 変更内容

- Removed `yarn export` references from README.md:
  - Changed "Build & Export" section to "Build" 
  - Removed `yarn export` and `npm run export` commands
  - Updated Available Scripts section to remove `yarn export`
- Added accurate script references:
  - Added `yarn start` - Start production server
  - Added `yarn lint:text` - Run textlint on markdown content
- Clarified that build process automatically includes static export

- README.mdから`yarn export`の参照を削除:
  - "Build & Export"セクションを"Build"に変更
  - `yarn export`と`npm run export`コマンドを削除
  - Available Scriptsセクションから`yarn export`を削除
- 正確なスクリプト参照を追加:
  - `yarn start` - プロダクションサーバーを開始
  - `yarn lint:text` - マークダウンコンテンツでtextlintを実行
- ビルドプロセスが自動的に静的エクスポートを含むことを明確化

## Impact scope / 影響範囲

Documentation-only changes that align README.md with the actual package.json scripts. No functional changes to the application.

README.mdを実際のpackage.jsonスクリプトと整合させるドキュメントのみの変更。アプリケーションの機能変更はありません。

## Testing / 動作確認

- [x] Verified all referenced commands exist in package.json
- [x] Confirmed no broken command references remain
- [x] Checked that documentation accurately reflects current build process

- [x] 参照されているすべてのコマンドがpackage.jsonに存在することを確認
- [x] 壊れたコマンド参照が残っていないことを確認
- [x] ドキュメントが現在のビルドプロセスを正確に反映していることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)