### PR TITLE
chore: add merge-renovate-prs skill for automated dependency PR review

### DIFF
--- a/.claude/commands/merge-renovate-prs.md
+++ b/.claude/commands/merge-renovate-prs.md
@@ -1,0 +1,96 @@
+---
+description: Review and merge all open Renovate dependency update PRs
+allowed-tools: ["Bash", "Read", "Edit", "Write", "Glob", "Grep", "Agent"]
+---
+
+# Merge Renovate PRs
+
+You are a senior software engineer responsible for reviewing and merging Renovate dependency update PRs.
+
+## Procedure
+
+### 1. Check Dependency Dashboard
+
+```bash
+gh issue view 37 --json body --jq '.body'
+```
+
+- If there are pending updates not yet turned into PRs (unchecked checkboxes under sections like "Open" or "Rate-Limited"), inform the user and suggest they check the boxes on the Dashboard issue to trigger PR creation.
+- If there are no open or pending branches, report that there are no Renovate PRs to process.
+
+### 2. List all open Renovate PRs
+
+```bash
+gh pr list --author "app/renovate" --state open --json number,title,headRefName
+```
+
+### 3. For each PR, perform the following in order:
+
+#### a. Review the diff
+
+```bash
+gh pr diff <PR_NUMBER>
+```
+
+- Verify the changes are dependency updates only (package.json, bun.lock, workflow files, etc.)
+- Flag anything unexpected (source code changes, config modifications beyond expected scope)
+
+#### b. Check CI status
+
+```bash
+gh pr view <PR_NUMBER> --json statusCheckRollup --jq '[.statusCheckRollup[] | {name, status, conclusion}]'
+```
+
+- **`check` CI is the important one.** This runs lint and build verification.
+- **`claude-review` failures can be ignored** — they commonly fail on workflow file changes due to token validation issues.
+
+#### c. If check CI passes → Merge
+
+```bash
+gh pr merge <PR_NUMBER> --squash
+```
+
+- If merge fails with `workflow` scope error (when PR modifies `.github/workflows/` files), report to the user that they need to merge this PR manually via GitHub Web UI.
+
+#### d. If check CI fails → Investigate
+
+1. Get the failed run logs:
+   ```bash
+   gh pr checks <PR_NUMBER> --json name,state,link --jq '.[] | select(.name == "check")'
+   gh run view <RUN_ID> --log-failed
+   ```
+
+2. If the failure is a build error caused by breaking changes in a major update:
+   - Checkout the PR branch: `gh pr checkout <PR_NUMBER>`
+   - Install dependencies: `bun install --frozen-lockfile`
+   - Fix the breaking changes in the source code
+   - Run `bun run build` and `bun run lint` to verify
+   - Commit the fix with a descriptive message
+   - Push and wait for CI to pass
+   - Merge when CI passes
+
+3. If the failure is complex or unclear, skip the PR and report it to the user.
+
+#### e. If CI is still pending → Wait
+
+```bash
+gh run watch <RUN_ID>
+```
+
+Wait for CI to complete before proceeding.
+
+### 4. After processing all PRs
+
+- Switch back to main and pull: `git checkout main && git pull`
+- Report a summary table of all PRs and their final status (merged, skipped, needs manual action)
+
+## Important Notes
+
+- Always use `--squash` for merging (merge commits are disabled on this repository)
+- The `claude-review` check failure on workflow file changes is expected and can be ignored
+- Breaking changes in major updates may require code fixes — common examples:
+  - Renamed/removed exports (e.g., lucide icon name changes)
+  - Changed API signatures
+  - Updated peer dependency requirements
+- Use Conventional Commits format for any fix commits you create
+- Process PRs one at a time, in order of PR number


### PR DESCRIPTION
## Background / 背景

Renovateによる依存更新PRのレビュー・マージ作業を自動化するClaude Codeスキルを追加する。
毎週のRenovate PR処理を `/merge-renovate-prs` コマンドで実行できるようにする。

## Changes / 変更内容

- `.claude/commands/merge-renovate-prs.md` を新規作成
  - Dependency Dashboard (#37) の確認
  - 全open Renovate PRのdiff確認・CI確認・squash merge
  - CI失敗時の原因調査・breaking changes修正
  - workflow scopeエラー時のユーザー通知

## Impact scope / 影響範囲

- Claude Codeのスキル定義のみ。サイトの動作には影響なし。

## Testing / 動作確認

- [x] スキルファイルの構文・構造確認
- [x] 今回のRenovate PR (#38〜#42) の処理フローに基づいて作成