### PR TITLE
chore: remove unused husky and fix stale component names in docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ This is a personal resume/portfolio website built with Astro, featuring a static
 ### File Structure
 - `/src/pages/` - Astro pages
 - `/src/layouts/` - Astro layout components
-- `/src/components/` - Astro components (Sidebar, ThemeToggle, brand icons)
+- `/src/components/` - Astro components (SideNav, NavLinks, section components, brand icons)
 - `/src/styles/` - Global CSS with Tailwind
 - `/contents/` - Archived content files (reference only, not used by the site)
 - `/public/` - Static assets
@@ -38,9 +38,8 @@ This is a personal resume/portfolio website built with Astro, featuring a static
 ### Core Components
 - **Layout** (`src/layouts/Layout.astro`) - Root layout with sidebar, dark mode support, and Inter font
 - **Index Page** (`src/pages/index.astro`) - Renders resume content from TypeScript data files
-- **Sidebar** (`src/components/Sidebar.astro`) - Profile info and contact links
-- **ThemeToggle** (`src/components/ThemeToggle.astro`) - Dark/light mode toggle button
-- **GithubIcon/TwitterIcon** (`src/components/`) - Custom SVG icon components
+- **SideNav** (`src/components/SideNav.astro`) - Profile info, language switcher, and theme toggle
+- **GithubIcon/XIcon** (`src/components/`) - Custom SVG icon components
 
 ### Content Management
 Resume content is managed through TypeScript data files in `/src/data/` (`ja.ts`, `en.ts`, `shared.ts`).

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Resume content is managed through TypeScript data files in `src/data/` (`ja.ts`,
 
 ```
 ├── src/
-│   ├── components/    # Astro components (Sidebar, ThemeToggle, icons)
+│   ├── components/    # Astro components (SideNav, NavLinks, section components, icons)
 │   ├── layouts/       # Layout components
 │   ├── pages/         # Astro pages
 │   ├── styles/        # Global CSS

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,6 @@
         "@typescript-eslint/parser": "^8.0.0",
         "eslint": "^10",
         "eslint-plugin-astro": "^1.0.0",
-        "husky": "^9.1.7",
         "tailwindcss": "^4.2.0",
         "typescript": "^6.0.0",
       },
@@ -575,8 +574,6 @@
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
     "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
-
-    "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@typescript-eslint/parser": "^8.0.0",
     "eslint": "^10",
     "eslint-plugin-astro": "^1.0.0",
-    "husky": "^9.1.7",
     "tailwindcss": "^4.2.0",
     "typescript": "^6.0.0"
   }


### PR DESCRIPTION
## Background / 背景

リポジトリの整備として、未使用の依存パッケージとドキュメントの不整合を解消する。

## Changes / 変更内容

- `husky` を devDependencies から削除（`.husky/` ディレクトリが存在せず、git hooks が未設定のため不要）
- CLAUDE.md / README.md のコンポーネント名を現状に合わせて更新:
  - `Sidebar` → `SideNav`
  - `ThemeToggle` → SideNav に統合済みのため削除
  - `TwitterIcon` → `XIcon`

## Impact scope / 影響範囲

- サイトの表示・ビルドには影響なし
- ドキュメントの正確性が向上

## Testing / 動作確認

- [x] `bun install` が正常に完了すること
- [x] `bun run lint` が正常に完了すること
- [x] `bun run build` が正常に完了すること（2ページ生成）